### PR TITLE
Feature/save and show saved posters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -102,9 +102,12 @@ var savedPosters = [];
 var currentPoster;
 
 // query selector variables go here 👇
+// poster variables
 var posterImage = document.querySelector('.poster-img');
 var posterTitle = document.querySelector('.poster-title');
 var posterQuote = document.querySelector('.poster-quote');
+
+//button variables
 var randomPosterButton = document.querySelector('.show-random')
 var savePostersButton = document.querySelector('.save-poster');
 var showSavedPostersButton = document.querySelector('.show-saved');
@@ -112,9 +115,14 @@ var makePostersButton = document.querySelector('.show-form');
 var takeMeBackButton = document.querySelector('.show-main');
 var backToMainButton = document.querySelector('.back-to-main');
 var showFormPosterButton = document.querySelector('.make-poster');
+
+//page view variables
 var posterForm = document.querySelector('.poster-form');
 var mainPoster = document.querySelector('.main-poster');
 var savedPostersView = document.querySelector('.saved-posters');
+var savedPostersGrid = document.querySelector('.saved-posters-grid');
+
+// user input variables
 var posterImageInput = document.querySelector('#poster-image-url');
 var posterTitleInput = document.querySelector('#poster-title');
 var posterQuoteInput = document.querySelector('#poster-quote');
@@ -127,6 +135,8 @@ showSavedPostersButton.addEventListener('click', showSavedPostersView);
 takeMeBackButton.addEventListener('click', showMainPostersSection);
 backToMainButton.addEventListener('click', showMainPostersSection);
 showFormPosterButton.addEventListener('click', displayUserMadePoster);
+savePostersButton.addEventListener('click', saveCurrentPoster);
+showSavedPostersButton.addEventListener('click', displaySavedPosters)
 
 // functions and event handlers go here 👇
 function getRandomIndex(array) {
@@ -181,4 +191,11 @@ function displayUserMadePoster(event) {
   images.push(posterImageInput.value);
 
   showMainPostersSection();
+}
+
+function saveCurrentPoster() {
+  currentPoster = new Poster(posterImage.src, posterTitle.innerText, posterQuote.innerText);
+  if (!savedPosters.includes(currentPoster)) {
+    savedPosters.push(currentPoster);
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -199,3 +199,14 @@ function saveCurrentPoster() {
     savedPosters.push(currentPoster);
   }
 }
+
+function displaySavedPosters() {
+  savedPostersGrid.innerHTML = ''
+   for (var i = 0; i < savedPosters.length; i++) {
+     savedPostersGrid.innerHTML += `<article class="mini-poster">
+     <img id="${savedPosters[i].id}" src="${savedPosters[i].imageURL}" alt="${savedPosters[i].title}">
+     <h1 class="mini-poster-title">${savedPosters[i].title}</h1>
+     <h3 class="mini-poster-quote">${savedPosters[i].quote}</h3>
+  </article>`
+   }
+ }


### PR DESCRIPTION
This adds iteration 3, which includes two functions that can execute the following tasks:

- When a user clicks the “Save This Poster” button, the current main poster will be added to the savedPosters array.
- If a user clicks the “Save This Poster” more than once on a single poster, it will still only be saved once (no duplicates)
- When a user clicks the “Show Saved Posters” button, we should see the saved posters section
- All the posters in the savedPosters array should be displayed in the saved posters grid section